### PR TITLE
Override bash args to avoid pipe errors

### DIFF
--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
       - name: Compilation
         id: build
-        shell: bash
+        shell: bash {0}
         run: |
           dpkg --add-architecture i386 && apt update
           apt-get install -y aptitude


### PR DESCRIPTION
Using `bash` for `shell` specifies `bash --noprofile --norc -eo pipefail {0}` in github pipelines (https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsshell), the exit code 141 is due to `yes` being piped into a script, and then `yes` being terminated by the script exiting while it has more output to give when `pipefail` is on.