### PR TITLE
Add support for LUG flavoured Proton builds

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -91,9 +91,9 @@ jobs:
       - name: Compilation
         shell: bash {0}
         run: |
-          ./build-lug-wine.sh --preset proton-default --version "$WINE_VERSION" --revision "$LUG_REV"
+          ./build-lug-wine.sh --preset proton --version "$WINE_VERSION" --revision "$LUG_REV"
       - name: Upload Archive
         uses: actions/upload-artifact@v4
         with:
-          name: "proton-default-build"
+          name: "lug-proton-build"
           path: ./output

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -29,7 +29,7 @@ env:
   WINE_VERSION: ${{ inputs.wine_version || github.event.inputs.wine_version }}
   LUG_REV: ${{ inputs.lug_rev || github.event.inputs.lug_rev }}
 jobs:
-  build:
+  build-wine:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,4 +71,28 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "${{ matrix.os }}-${{ matrix.preset }}-build"
+          path: ./output
+
+  build-proton:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space
+        uses: LizardByte/actions/actions/more_space@master
+        with:
+          analyze-space-savings: true
+          clean-all: true
+          safe-packages: "patch,git"
+      - name: Display Analysis
+        run: echo '${{ steps.cleanup.outputs.space-analysis }}'
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Compilation
+        shell: bash {0}
+        run: |
+          ./build-lug-wine.sh --preset proton-default --revision "$LUG_REV"
+      - name: Upload Archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: "proton-default-build"
           path: ./output

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space
+        id: cleanup
         uses: LizardByte/actions/actions/more_space@master
         with:
           analyze-space-savings: true

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Compilation
         shell: bash {0}
         run: |
-          ./build-lug-wine.sh --preset proton-default --revision "$LUG_REV"
+          ./build-lug-wine.sh --preset proton-default --version "$WINE_VERSION" --revision "$LUG_REV"
       - name: Upload Archive
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 jobs:
   ci_run:
-    uses: starcitizen-lug/lug-wine/.github/workflows/build-artifacts.yml@main
+    uses: "./.github/workflows/build-artifacts.yml"
     with:
       wine_version: ''
       lug_rev: '1'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
           echo "lug_rev=$lug_rev" >> $GITHUB_OUTPUT
   build:
     needs: parse
-    uses: starcitizen-lug/lug-wine/.github/workflows/build-artifacts.yml@main
+    uses: "./.github/workflows/build-artifacts.yml"
     with:
       wine_version: ${{ needs.parse.outputs.wine_version }}
       lug_rev: ${{ needs.parse.outputs.lug_rev }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "patches"]
 	path = patches
-	url = https://github.com/ProjectSynchro/patches.git
+	url = https://github.com/starcitizen-lug/patches
 [submodule "wine-tkg-git"]
 	path = wine-tkg-git
 	url = https://github.com/Frogging-Family/wine-tkg-git/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "patches"]
 	path = patches
-	url = https://github.com/starcitizen-lug/patches
+	url = https://github.com/ProjectSynchro/patches.git
 [submodule "wine-tkg-git"]
 	path = wine-tkg-git
 	url = https://github.com/Frogging-Family/wine-tkg-git/

--- a/build-lug-wine.sh
+++ b/build-lug-wine.sh
@@ -163,6 +163,10 @@ build_lug_proton() {
       sed -i 's|\.\./configure\.sh|\.\./configure\.sh --relabel-volumes|' proton-tkg.sh
   fi
   
+  # Even with _no_autoinstall="true", proton-tkg.sh will not move the artifact to ./built
+  # if it detects Steam. We must force it to ignore Steam to get the build in the expected location.
+  sed -i 's/_no_steampath="false"/_no_steampath="y"/' proton-tkg.sh
+
   yes|./proton-tkg.sh "./$config" "$@"
   echo "Proton build completed successfully."
 }
@@ -223,7 +227,7 @@ Usage: ./build-lug-wine <options>
   -a, --adhoc                   Comma-separated list of adhoc patches to apply
   -p, --preset                  Select a preset configuration:
                                   Wine:   default, staging-default, staging-wayland
-                                  Proton: proton-default
+                                  Proton: proton
   -o, --output                  Output directory for the build artifact (default: ./output)
   -r, --revision                Revision number for the build (default: 1)
 "

--- a/build-lug-wine.sh
+++ b/build-lug-wine.sh
@@ -142,6 +142,12 @@ prepare_preset() {
       sed -i "s/plain_version=\"\"/plain_version=\"wine-$wine_version\"/" "$TMP_BUILD_DIR/$config"
     fi
   fi
+  
+  # Inject Proton "bleeding tag" for Proton builds to tag builds.
+  if [ "$build_type" = "proton" ] && [ -n "$wine_version" ]; then
+    sed -i "s|^_bleeding_tag=.*|_bleeding_tag=\"$wine_version\"|" "$TMP_BUILD_DIR/proton-tkg/$config"
+    echo "Set _bleeding_tag to: $wine_version"
+  fi
 }
 
 build_lug_wine() {
@@ -223,7 +229,7 @@ usage() {
 Usage: ./build-lug-wine <options>
 ./build-lug-wine -p default -v 10.23 -r 1 -a default-to-wayland
   -h, --help                    Display this help message and exit
-  -v, --version                 Wine version to build e.g. "10.23" (default: latest git)
+  -v, --version                 Wine version (for Wine) or Proton tag (for Proton) to build (default: latest git)
   -a, --adhoc                   Comma-separated list of adhoc patches to apply
   -p, --preset                  Select a preset configuration:
                                   Wine:   default, staging-default, staging-wayland

--- a/build-lug-wine.sh
+++ b/build-lug-wine.sh
@@ -118,6 +118,12 @@ prepare_preset() {
       fi
     done
 
+    # Inject Proton "bleeding tag" for Proton builds to tag builds.
+    if [ -n "$wine_version" ]; then
+      sed -i "s|^_bleeding_tag=.*|_bleeding_tag=\"$wine_version\"|" "$TMP_BUILD_DIR/proton-tkg/$config"
+      echo "Set _bleeding_tag to: $wine_version"
+    fi
+
     echo "Copied LUG patches to wine-tkg-git/wine-tkg-userpatches/"
 
   else
@@ -143,11 +149,7 @@ prepare_preset() {
     fi
   fi
   
-  # Inject Proton "bleeding tag" for Proton builds to tag builds.
-  if [ "$build_type" = "proton" ] && [ -n "$wine_version" ]; then
-    sed -i "s|^_bleeding_tag=.*|_bleeding_tag=\"$wine_version\"|" "$TMP_BUILD_DIR/proton-tkg/$config"
-    echo "Set _bleeding_tag to: $wine_version"
-  fi
+
 }
 
 build_lug_wine() {

--- a/config/lug-proton-tkg-default.cfg
+++ b/config/lug-proton-tkg-default.cfg
@@ -83,7 +83,7 @@ _use_staging="true"
 _staging_version=""
 
 # Try to disable staging patches that we also disable for wine builds
-_staging_userargs="-W ntdll-ForceBottomUpAlloc -W ntdll-Hide_Wine_Exports"
+#_staging_userargs="-W ntdll-Hide_Wine_Exports"
 
 # GAME-SPECIFIC PATCHES
 

--- a/config/lug-proton-tkg-default.cfg
+++ b/config/lug-proton-tkg-default.cfg
@@ -127,7 +127,7 @@ _quake_champions_fix="true"
 
 # Set to "false" to disable building proton media converter - This is helpful for some games using unsupported video formats such as Resident Evil 8
 # We're only supporting 64-bit version of the lib in -tkg at this point - https://github.com/ValveSoftware/Proton/tree/proton_6.3/media-converter
-_build_mediaconv="true"
+_build_mediaconv="false"
 
 # Set to "true" to re-use previoulsy built gst-related libs (mediaconverter, gstreamer, ffmpeg, faudio)
 # Set to "false" to explicitly not re-use previoulsy built gst-related libs
@@ -139,10 +139,10 @@ _reuse_built_gst=""
 # Set to "true" to enable building 64-bit patched gstreamer & plugins - This is helpful to support video formats not covered by your distro packages
 # Will build orc, gstreamer, gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav
 # _build_mediaconv can be set to false when this is enabled and Steam's shader precaching is disabled
-_build_gstreamer="false"
+_build_gstreamer="true"
 # Set to "true" to also enable building 32-bit patched gstreamer & plugins
 # Depends on _build_gstreamer="true"
-_lib32_gstreamer="false"
+_lib32_gstreamer="true"
 
 # Set to "true" to enable building ffmpeg
 # Depends on _build_gstreamer="true"
@@ -198,7 +198,7 @@ _use_ntsync="false"
 
 # community patches - add patches (separated by a space) of your choice by name from the community-patches dir - https://github.com/Frogging-Family/community-patches - proton-tkg, just like wine-tkg-git,  uses the wine-tkg-git patches subdir
 # example: _community_patches="amdags.mypatch GNUTLShack.mypatch"
-#_community_patches="amd_fsr_fshack-alternative.mypatch amdags-proton.mypatch atiadlxx-proton.mypatch 0002-proton_QPC.mypatch ntdll_Map_top-down_if_dll_characteristics_include_DYNAMIC_BASE.mypatch EA_desktop_fix.mypatch Shell32-CreateDirectoryInDestinationInFileOp-Move-multiop.mypatch"
+_community_patches=""
 
 _user_patches="true"
 _user_patches_no_confirm="false"

--- a/config/lug-proton-tkg-default.cfg
+++ b/config/lug-proton-tkg-default.cfg
@@ -66,6 +66,9 @@ _proton_dxvk_configfile=""
 #  "none" - Silence the prompt
 _LOCAL_PRESET="valve-exp-bleeding"
 
+# Set a tag to use when building Proton, allows for reproducible builds
+_bleeding_tag=""
+
 # Add GloriousEggroll game patches and hotfixes when using a Valve profile with staging enabled
 # ! This will only affect Valve + staging trees !
 # List of patches applied with this option enabled: assettocorsa-hud killer-instinct-winevulkan_fix FFVII-and-SpecialK-powerprof 65-proton-fake_current_res_patches unity_crash_hotfix Fix-regression-introduced-by-0e7fd41 15aa8c6-fix-star-citizen-bug-52956 0001-winex11.drv-Define-ControlMask-when-not-available 0002-include-Add-THREAD_POWER_THROTTLING_STATE-type 0003-ntdll-Fake-success-for-ThreadPowerThrottlingState

--- a/config/lug-proton-tkg-default.cfg
+++ b/config/lug-proton-tkg-default.cfg
@@ -1,0 +1,215 @@
+# 'Wine-to-rule-them-all' - Proton-TkG simple config file
+
+##
+##   This config file contains the basic settings of your build.
+##   For deeper configuration, see proton-tkg-profiles/advanced-customization.cfg
+##
+
+# This is a simplified config file with minimal comments. See ../wine-tkg-git/customization.cfg for more details.
+# Some options will be missing from this config file compared to wine-tkg-git as they are enforced.
+
+#### NON-MAKEPKG OPTIONS (Won't affect makepkg builds) ####
+
+# Set to true to get a prompt after the 64-bit part is built, enabling package switching before building the 32-bit side.
+# This is a workaround for distros shipping broken devel packages that can't coexist as multilib
+_nomakepkg_midbuild_prompt="false"
+
+# Enable dependency autoresolver for non-makepkg builds - Set to true to automatically install missing dependencies for your distro.
+# This will autodetect your OS and install the required dependencies for building wine-tkg using the appropriate package manager.
+# The autoresolver will also attempt to use the best available privileged escalation method for your system (sudo, doas, etc.)
+_nomakepkg_dependency_autoresolver="false"
+
+# Set to true if you want to skip the uninstaller at the end of proton-tkg building
+_skip_uninstaller="true"
+
+# Set to true if you do not want your build to be automatically moved to your compatibilitytools.d dir
+_no_autoinstall="true"
+
+####
+
+
+# PROTON-TKG-MISC OPTIONS
+
+# SteamDeck support additions
+_tabtip="true"
+
+# Set Pulseaudio latency to 60ms - Can help with sound crackling issues on some configs (and introduce crackling on others)
+_proton_pulse_lowlat="false"
+
+# Enable Winetricks prompt on game launch - Will use your system winetricks, so you need it installed
+_proton_winetricks="false"
+
+
+# DXVK
+
+# Valid options::
+# "git" - Recommended and default - Will build current master with dxvk_config patch to allow for enhanced vkd3d compatibility
+# "prebuilt" - For builds made with dxvk-tools for example
+# "release" - using github's latest
+# "false" - disabled
+# Setting it to "true" will default to "release"
+_use_dxvk="git"
+
+# hud : https://github.com/doitsujin/dxvk#hud
+# configfile : https://github.com/doitsujin/dxvk/wiki/Configuration#configuration-file
+_proton_dxvk_hud=""
+_proton_dxvk_configfile=""
+
+
+# WINE FLAVOUR SETTINGS
+
+# Override config with one of the presets from /wine-tkg-profiles dir. Leave empty to be prompted.
+# Custom presets for proton :
+#  "valve" (builds against current valve proton tree)
+#  "valve-exp" (builds against current valve proton-experimental tree)
+#  "valve-exp-bleeding" (builds against current valve proton-experimental-bleeding-edge tree)
+#  "none" - Silence the prompt
+_LOCAL_PRESET="valve-exp-bleeding"
+
+# Add GloriousEggroll game patches and hotfixes when using a Valve profile with staging enabled
+# ! This will only affect Valve + staging trees !
+# List of patches applied with this option enabled: assettocorsa-hud killer-instinct-winevulkan_fix FFVII-and-SpecialK-powerprof 65-proton-fake_current_res_patches unity_crash_hotfix Fix-regression-introduced-by-0e7fd41 15aa8c6-fix-star-citizen-bug-52956 0001-winex11.drv-Define-ControlMask-when-not-available 0002-include-Add-THREAD_POWER_THROTTLING_STATE-type 0003-ntdll-Fake-success-for-ThreadPowerThrottlingState
+_use_GE_patches="true"
+
+# Add GloriousEggroll patches and hotfixes for winewayland
+_GE_WAYLAND="true"
+
+# Set to true to pass --with-wayland --with-vulkan configure arguments
+# !! Requires a compatible wine tree (9.0+ recommended) !!
+_wayland_driver="true"
+
+_plain_version=""
+_use_staging="true"
+_staging_version=""
+
+# Try to disable staging patches that we also disable for wine builds
+_staging_userargs="-W ntdll-ForceBottomUpAlloc -W ntdll-Hide_Wine_Exports"
+
+# GAME-SPECIFIC PATCHES
+
+# Enable support for Proton's Battleye runtime - Needs the package to be installed in Steam
+_proton_battleye_support="true"
+
+# Enable support for Proton's EAC bridge - Needs the package to be installed in Steam
+_proton_eac_support="true"
+
+_ffxivlauncher_fix="false"
+_sims3_fix="false"
+_mtga_fix="false"
+_mwo_fix="false"
+
+# Shared gpu resources support:
+# Shared texture resources for d3d9 and d3d11 - https://github.com/doitsujin/dxvk/pull/2516
+# Requires DXVK 1.10.1+
+# ID3D11Fence and ID3D12Fence sharing - https://github.com/doitsujin/dxvk/pull/2608 https://github.com/HansKristian-Work/vkd3d-proton/pull/1175
+# Requires DXVK 1.10.3+, VKD3D-Proton 2.7+
+_shared_gpu_resources="false"
+
+# Fix for Assetto Corsa performance drop when HUD elements are displayed - https://bugs.winehq.org/show_bug.cgi?id=46955
+_assettocorsa_hudperf_fix="true"
+
+# Fixes for Mortal Kombat 11 - Requires staging, _proton_fs_hack="true", native mfplat (win7) or staging mfplat support and a different GPU driver than RADV
+# On Wine 5.2 (up to b1c748c8) and lower, it needs to be toogled on with the WINE_LOW_USER_SPACE_LIMIT=1 envvar
+_mk11_fix="true"
+
+# ! _re4_fix="true" requires _wined3d_additions="false" or it will get ignored ! - Not needed when using DXVK
+_re4_fix="false"
+
+# Background music on King of Fighters 98 and 2002 is silent on Wine-staging and the `xactengine-initial` patchset was found to introduce the issue. Set to "true" to disable it as a workaround. 
+_kof98_2002_BGM_fix="false"
+
+# Fix for Quake Champions by Paul Gofman for Proton - Depends on _protonify="true" and _use_staging="true"
+# This patchset breaks Genshin Impact
+_quake_champions_fix="true"
+
+
+# OTHER PATCHES
+
+# Set to "false" to disable building proton media converter - This is helpful for some games using unsupported video formats such as Resident Evil 8
+# We're only supporting 64-bit version of the lib in -tkg at this point - https://github.com/ValveSoftware/Proton/tree/proton_6.3/media-converter
+_build_mediaconv="true"
+
+# Set to "true" to re-use previoulsy built gst-related libs (mediaconverter, gstreamer, ffmpeg, faudio)
+# Set to "false" to explicitly not re-use previoulsy built gst-related libs
+# Default (empty value) will prompt if an existing gst dir is found
+# !!! There is not detection regarding what was and wasn't built, the previously built gst dir will be used as it was on last successfuly build, independently of the below options !!!
+# !!! If you want to add features you didn't build before (for example ffmpeg or lib32), you'll need to enable those and rebuild without this option first !!!
+_reuse_built_gst=""
+
+# Set to "true" to enable building 64-bit patched gstreamer & plugins - This is helpful to support video formats not covered by your distro packages
+# Will build orc, gstreamer, gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav
+# _build_mediaconv can be set to false when this is enabled and Steam's shader precaching is disabled
+_build_gstreamer="false"
+# Set to "true" to also enable building 32-bit patched gstreamer & plugins
+# Depends on _build_gstreamer="true"
+_lib32_gstreamer="false"
+
+# Set to "true" to enable building ffmpeg
+# Depends on _build_gstreamer="true"
+# Enabling _lib32_gstreamer above will also enable lib32 for this option
+_build_ffmpeg="true"
+
+# Set to "true" to enable building FAudio
+# Depends on _build_gstreamer="true"
+# Enabling _lib32_gstreamer above will also enable lib32 for this option
+_build_faudio="true"
+
+_FS_bypass_compositor="true"
+_proton_fs_hack="true"
+
+# Various vulkan patches from Proton 10 for wine - Requires 10.0+
+#WARNING: For now not sure if shared gpu resoures is working. Need some testing with games which requires this - https://github.com/Frogging-Family/wine-tkg-git/issues/1328#issuecomment-2921990068
+# This is a brittle patchset and will break often, beware
+_proton_winevulkan="false"
+
+_proton_mf_patches="true"
+# Joshua Ashton's take on making wine dialogs and menus less win95-ish - https://github.com/Joshua-Ashton/wine/tree/wine-better-theme
+_use_josh_flat_theme="true"
+
+# Other misc proton patches and hacks - Notably contains fixes for some native vk games (such as Doom Eternal) as well as Rockstar launcher
+# Also enables some winevulkan performance optimizations - https://github.com/Joshua-Ashton/proton-wine/tree/winevulkan-opt (fs hack) - https://github.com/Joshua-Ashton/wine/commits/winevulkan-opt-mainline (no fs hack)
+_protonify="true"
+
+
+# LEGACY
+
+# Legacy? Those are enabled on Valve trees always
+# Ntsync replaces them on mainline-based builds
+_use_esync="false"
+_use_fsync="false"
+
+# NTsync - Disable with PROTON_NO_NTSYNC=1 or WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable NTsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
+# more info about NTsync and feedback topic - https://github.com/Frogging-Family/wine-tkg-git/issues/936
+# !! For building and using requires special linux-tkg build with winesync module and header (or https://aur.archlinux.org/packages/winesync-dkms/) !!
+# !! Not compatible with Valve trees and some other patches. On Staging depends on fsync patches !!
+# !! For plain Wine required disabling esync and fsync patches applying !!
+_use_fastsync="false"
+
+# NTsync5 - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/ntsync5
+# !! For building, requires full ntsync kernel UAPI header (if applicable, replace broken ntsync.h from mainline >= 6.10) !!
+# !! For using, requires ntsync kernel module (from special linux-tkg build, or separately built against kernel >= 6.8 from NTsync5 patchset) !!
+# !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!
+# !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
+# !! Enabled by default on Valve trees when available, independently of this option !!
+_use_ntsync="false"
+
+
+# USER PATCHES
+
+# community patches - add patches (separated by a space) of your choice by name from the community-patches dir - https://github.com/Frogging-Family/community-patches - proton-tkg, just like wine-tkg-git,  uses the wine-tkg-git patches subdir
+# example: _community_patches="amdags.mypatch GNUTLShack.mypatch"
+#_community_patches="amd_fsr_fshack-alternative.mypatch amdags-proton.mypatch atiadlxx-proton.mypatch 0002-proton_QPC.mypatch ntdll_Map_top-down_if_dll_characteristics_include_DYNAMIC_BASE.mypatch EA_desktop_fix.mypatch Shell32-CreateDirectoryInDestinationInFileOp-Move-multiop.mypatch"
+
+_user_patches="true"
+_user_patches_no_confirm="false"
+
+# Set to "false" to prompt about all non-critical hotfix patches at build time, or "ignore" to ignore all non-critical hotfix patches without confirmation
+# Default ("true") will apply all non-critical hotfix patches without confirmation
+_hotfixes_no_confirm="true"
+# Set to false to disable staging mfplat restoration in case a hotfix is available and _hotfixes_no_confirm is set to "true"
+_hotfixansw_staging_mfplat=""
+# Set to false to disable staging pulseaudio restoration in case a hotfix is available and _hotfixes_no_confirm is set to "true"
+_hotfixansw_staging_pulse=""
+
+# Enable CI build mode for unattended builds
+_ci_build="true"


### PR DESCRIPTION
Does what it says on the tin :smile: 

Builds Proton using the umu-sdk (steamruntime sniper) environment so for local builds, you'll need Docker or Podman to build.
For CI, we can use the docker socket that is available on the runners to build Proton, so I added a new job that can do that.

What's worth looking into: 
- Naming scheme
- Versioning scheme

I also noticed with the outputted builds, protonfixes aren't included so we may need to add that ourselves (easy enough to do)

TODO:
- [x] Rebase `cache-committed-size.patch`
- [x] Rebase `sc_gpumem.patch`
- [ ] Build and integrate protonfixes so umu-run works without manual tweaks
- [ ] Verify build works properly for running the game normally and in VR. 